### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# GloBee Library for Python 2
+# BitPay Library for Python 2
 
-Powerful, flexible, lightweight interface to the cryptographically secure GloBee Bitcoin & Altcoin Payment Gateway API.
+Powerful, flexible, lightweight interface to the cryptographically secure BitPay Bitcoin Payment Gateway API.
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://raw.githubusercontent.com/bitpay/bitpay-python-py2/master/LICENSE.txt)
 [![Travis](https://img.shields.io/travis/bitpay/bitpay-python-py2.svg?style=flat-square)](https://travis-ci.org/bitpay/bitpay-python-py2)
@@ -10,24 +10,24 @@ Powerful, flexible, lightweight interface to the cryptographically secure GloBee
 [![Scrutinizer](https://img.shields.io/scrutinizer/g/bitpay/bitpay-python-py2.svg?style=flat-square)](https://scrutinizer-ci.com/g/bitpay/bitpay-python-py2/)
 [![Coveralls](https://img.shields.io/coveralls/bitpay/bitpay-python-py2.svg?style=flat-square)](https://coveralls.io/r/bitpay/bitpay-python-py2)
 
-This library is only compatible with Python 2. If you're using Python 3.x, please use our separate [bitpay-python](https://github.com/GloBee-Official/bitpay-python) library.
+This library is only compatible with Python 2. If you're using Python 3.x, please use our separate [bitpay-python](https://github.com/ionux/bitpay-python) library.
 
 ## Getting Started
 To get up and running with this library quickly, see these getting started guides:
-* https://github.com/GloBee-Official/bitpay-python-py2/blob/master/GUIDE.md
+* https://github.com/bitpay/bitpay-python-py2/blob/master/GUIDE.md
 * https://support.bitpay.com/hc/en-us/articles/115003001203-How-do-I-configure-and-use-the-BitPay-Python-Library-
 * https://bitpay.com/docs/testing
 
 ## API Documentation
 
-API Documentation is available on the [GloBee site](https://globee.com/api-docs).
+API Documentation is available on the [BitPay site](https://bitpay.com/api).
 
 ## Running the Tests
 
-Before running the behavior tests, you will need a test.globee.com account and you will need to set the local constants.
+Before running the behavior tests, you will need a test.bitpay.com account and you will need to set the local constants.
 
 To set constants:
-    > source tasks/set_constants.sh "https://test.globee.com" your@email yourpassword
+    > source tasks/set_constants.sh "https://test.bitpay.com" your@email yourpassword
 
 To run unit tests:
     > nosetests
@@ -39,12 +39,12 @@ To run behavior tests:
 
 Let us know! Send a pull request or a patch. Questions? Ask! We're here to help. We will respond to all filed issues.
 
-**GloBee Support:**
+**BitPay Support:**
 
-* [GitHub Issues](https://github.com/GloBee-Official/bitpay-python-py2/issues)
+* [GitHub Issues](https://github.com/bitpay/bitpay-python-py2/issues)
   * Open an issue if you are having issues with this library
-* [Support](https://globee.com)
-  * GloBee merchant support documentation
+* [Support](https://help.bitpay.com)
+  * BitPay merchant support documentation
 
 Sometimes a download can become corrupted for various reasons.  However, you can verify that the release package you downloaded is correct by checking the md5 checksum "fingerprint" of your download against the md5 checksum value shown on the Releases page.  Even the smallest change in the downloaded release package will cause a different value to be shown!
   * If you are using Windows, you can download a checksum verifier tool and instructions directly from Microsoft here: http://www.microsoft.com/en-us/download/details.aspx?id=11533

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Powerful, flexible, lightweight interface to the cryptographically secure GloBee
 
 [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://raw.githubusercontent.com/bitpay/bitpay-python-py2/master/LICENSE.txt)
 [![Travis](https://img.shields.io/travis/bitpay/bitpay-python-py2.svg?style=flat-square)](https://travis-ci.org/bitpay/bitpay-python-py2)
-[![Latest Version](https://pypip.in/version/bitpay_py2/badge.svg?style=flat-square)](https://pypi.python.org/pypi/bitpay-py2/)
-[![Supported Python versions](https://pypip.in/py_versions/bitpay_py2/badge.svg?style=flat-square)](https://pypi.python.org/pypi/bitpay-py2/)
+[![Latest Version](https://img.shields.io/pypi/v/bitpay_py2.svg?style=flat-square)](https://pypi.python.org/pypi/bitpay-py2/)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/bitpay_py2.svg?style=flat-square)](https://pypi.python.org/pypi/bitpay-py2/)
 [![Code Climate](https://img.shields.io/codeclimate/github/bitpay/bitpay-python-py2.svg?style=flat-square)](https://codeclimate.com/github/bitpay/bitpay-python-py2)
 [![Scrutinizer](https://img.shields.io/scrutinizer/g/bitpay/bitpay-python-py2.svg?style=flat-square)](https://scrutinizer-ci.com/g/bitpay/bitpay-python-py2/)
 [![Coveralls](https://img.shields.io/coveralls/bitpay/bitpay-python-py2.svg?style=flat-square)](https://coveralls.io/r/bitpay/bitpay-python-py2)


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20globee-py2))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `globee-py2`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.